### PR TITLE
Allow to use multiple trigger chars associated with multiple items collections

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,15 @@
+::ng-deep .custom-list {
+  min-width: 320px;
+}
+
+::ng-deep .custom-list .header {
+  text-align: center;
+}
+
+::ng-deep .custom-list li.active{
+  background-color: transparent;
+}
+
+::ng-deep .custom-list li:hover{
+  background-color: #f7f7f9;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -14,7 +14,7 @@ and content editable fields. Try entering some @names below.</p>
 <div [mention]="items" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
 
 <h3>Content Editable with Multiple Triggers (@, #)</h3>
-<div [mention]="[{charTrigger: '@', items: items}, {charTrigger: '#', items: tagsItems}]" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
+<div [mention]="[{charTrigger: '@', items: items}, {charTrigger: '#', items: tagsItems, startsWithCharTrigger: true}]" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
 
 <!--<h3>Embedded Editor</h3>-->
 <!--<app-demo-tinymce></app-demo-tinymce>-->

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -13,8 +13,11 @@ and content editable fields. Try entering some @names below.</p>
 <h3>Content Editable</h3>
 <div [mention]="items" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
 
-<h3>Embedded Editor</h3>
-<app-demo-tinymce></app-demo-tinymce>
+<h3>Content Editable with Multiple Triggers (@, #)</h3>
+<div [mention]="[{charTrigger: '@', items: items}]" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
+
+<!--<h3>Embedded Editor</h3>-->
+<!--<app-demo-tinymce></app-demo-tinymce>-->
 
 <!-- other demos that can be enabled -->
 <!-- <app-demo-async></app-demo-async> -->

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -14,7 +14,7 @@ and content editable fields. Try entering some @names below.</p>
 <div [mention]="items" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
 
 <h3>Content Editable with Multiple Triggers (@, #)</h3>
-<div [mention]="[{charTrigger: '@', items: items}]" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
+<div [mention]="[{charTrigger: '@', items: items}, {charTrigger: '#', items: tagsItems}]" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
 
 <!--<h3>Embedded Editor</h3>-->
 <!--<app-demo-tinymce></app-demo-tinymce>-->

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -19,11 +19,11 @@
      class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
 
 <h3>Content Editable with auto-complete list custom appearance</h3>
-<div [mention]="items" [mentionListConfig]="{headerTemplate: customHeader}" class="form-control" contenteditable="true"
+<div [mention]="items" [mentionListConfig]="{headerTemplate: customHeader, listClasses: 'custom-list'}" class="form-control" contenteditable="true"
      style="border:1px lightgrey solid;min-height:88px"></div>.
 
 <ng-template #customHeader>
-  <div class="header card-body" style="user-select: none;">
+  <div class="header" style="user-select: none;">
     <span><strong>↑</strong> <strong>↓</strong> to navigate</span>
     <span><strong>↵</strong> to select</span>
     <span><strong>esc</strong> to dismiss</span>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,7 +2,7 @@
 
 <p>Simple Angular mentions inspired by <a href="http://jeff-collins.github.io/ment.io/#/">Ment.io</a>.</p>
 <p style="color:grey">Supports auto-complete for mentions in text input fields, text areas,
-and content editable fields. Try entering some @names below.</p>
+  and content editable fields. Try entering some @names below.</p>
 
 <h3>Minimal</h3>
 <input [mention]="items" class="form-control" type="text">
@@ -11,10 +11,24 @@ and content editable fields. Try entering some @names below.</p>
 <textarea [mention]="items" class="form-control" cols="60" rows="4"></textarea>
 
 <h3>Content Editable</h3>
-<div [mention]="items" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
+<div [mention]="items" class="form-control" contenteditable="true"
+     style="border:1px lightgrey solid;min-height:88px"></div>
 
 <h3>Content Editable with Multiple Triggers (@, #)</h3>
-<div [mention]="[{charTrigger: '@', items: items}, {charTrigger: '#', items: tagsItems, startsWithCharTrigger: true}]" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
+<div [mention]="[{charTrigger: '@', items: items}, {charTrigger: '#', items: tagsItems, startsWithCharTrigger: true}]"
+     class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
+
+<h3>Content Editable with auto-complete list custom appearance</h3>
+<div [mention]="items" [mentionListConfig]="{headerTemplate: customHeader}" class="form-control" contenteditable="true"
+     style="border:1px lightgrey solid;min-height:88px"></div>.
+
+<ng-template #customHeader>
+  <div class="header card-body" style="user-select: none;">
+    <span><strong>↑</strong> <strong>↓</strong> to navigate</span>
+    <span><strong>↵</strong> to select</span>
+    <span><strong>esc</strong> to dismiss</span>
+  </div>
+</ng-template>
 
 <!--<h3>Embedded Editor</h3>-->
 <!--<app-demo-tinymce></app-demo-tinymce>-->
@@ -25,4 +39,7 @@ and content editable fields. Try entering some @names below.</p>
 <!-- <app-demo-template></app-demo-template> -->
 
 <br><p style="color:grey">angular-mentions on <a href="https://github.com/dmacfarlane/angular-mentions">Github</a></p>
-<a href="https://github.com/dmacfarlane/angular-mentions"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
+<a href="https://github.com/dmacfarlane/angular-mentions"><img style="position: absolute; top: 0; right: 0; border: 0;"
+                                                               src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67"
+                                                               alt="Fork me on GitHub"
+                                                               data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 
 import { COMMON_NAMES } from './common-names';
+import { COMMON_TAGS } from './common-tags'
 
 /**
  * Demo app showing usage of the mentions directive.
@@ -12,4 +13,5 @@ import { COMMON_NAMES } from './common-names';
 })
 export class AppComponent {
   items: string[] = COMMON_NAMES;
+  tagsItems: string[] = COMMON_TAGS;
 }

--- a/src/app/common-tags.ts
+++ b/src/app/common-tags.ts
@@ -1,0 +1,2 @@
+
+export const COMMON_TAGS: string[] = ['#development', '#testing', '#production', '#master'];

--- a/src/app/demo-template/demo-template.component.html
+++ b/src/app/demo-template/demo-template.component.html
@@ -7,5 +7,5 @@
 
 <h3>Input</h3>
 <input [mention]="complexItems" class="form-control" type="text"
-       [mentionConfig]="{mentionSelect: format}" 
-       [mentionListTemplate]="mentionListTemplate">
+       [mentionConfig]="{mentionSelect: format}"
+       [mentionListConfig]="{mentionListTemplate: mentionListTemplate}">

--- a/src/mention/mention-list.component.ts
+++ b/src/mention/mention-list.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, ElementRef, Output, EventEmitter, ViewChild, ContentChild, Input,
+  Component, ElementRef, Output, EventEmitter, ViewChild, Input,
   TemplateRef, OnInit
 } from '@angular/core';
 
@@ -21,11 +21,11 @@ import { getCaretCoordinates } from './caret-coords';
         max-height: 300px;
         overflow: auto;
       }
-    `,`
+    `, `
       [hidden] {
         display: none;
       }
-    `,`
+    `, `
       li.active {
         background-color: #f7f7f9;
       }
@@ -44,14 +44,14 @@ import { getCaretCoordinates } from './caret-coords';
     `
 })
 export class MentionListComponent implements OnInit {
-  @Input() labelKey: string = 'label';
+  @Input() labelKey = 'label';
   @Input() itemTemplate: TemplateRef<any>;
   @Output() itemClick = new EventEmitter();
   @ViewChild('list') list: ElementRef;
   @ViewChild('defaultItemTemplate') defaultItemTemplate: TemplateRef<any>;
   items = [];
-  activeIndex: number = 0;
-  hidden: boolean = false;
+  activeIndex = 0;
+  hidden = false;
   constructor(private _element: ElementRef) {}
 
   ngOnInit() {
@@ -68,25 +68,23 @@ export class MentionListComponent implements OnInit {
       coords = getCaretCoordinates(nativeParentElement, nativeParentElement.selectionStart);
       coords.top = nativeParentElement.offsetTop + coords.top + 16;
       coords.left = nativeParentElement.offsetLeft + coords.left;
-    }
-    else if (iframe) {
-      let context: { iframe: HTMLIFrameElement, parent: Element } = { iframe: iframe, parent: iframe.offsetParent };
+    } else if (iframe) {
+      const context: { iframe: HTMLIFrameElement, parent: Element } = { iframe: iframe, parent: iframe.offsetParent };
       coords = getContentEditableCaretCoords(context);
-    }
-    else {
-      let doc = document.documentElement;
-      let scrollLeft = (window.pageXOffset || doc.scrollLeft) - (doc.clientLeft || 0);
-      let scrollTop = (window.pageYOffset || doc.scrollTop) - (doc.clientTop || 0);
+    } else {
+      const doc = document.documentElement;
+      const scrollLeft = (window.pageXOffset || doc.scrollLeft) - (doc.clientLeft || 0);
+      const scrollTop = (window.pageYOffset || doc.scrollTop) - (doc.clientTop || 0);
 
       // bounding rectangles are relative to view, offsets are relative to container?
-      let caretRelativeToView = getContentEditableCaretCoords({ iframe: iframe });
-      let parentRelativeToContainer: ClientRect = nativeParentElement.getBoundingClientRect();
+      const caretRelativeToView = getContentEditableCaretCoords({ iframe: iframe });
+      const parentRelativeToContainer: ClientRect = nativeParentElement.getBoundingClientRect();
 
       coords.top = caretRelativeToView.top - parentRelativeToContainer.top + nativeParentElement.offsetTop - scrollTop;
       coords.left = caretRelativeToView.left - parentRelativeToContainer.left + nativeParentElement.offsetLeft - scrollLeft;
     }
-    let el: HTMLElement = this._element.nativeElement;
-    el.style.position = "absolute";
+    const el: HTMLElement = this._element.nativeElement;
+    el.style.position = 'absolute';
     el.style.left = coords.left + 'px';
     el.style.top = coords.top + 'px';
   }
@@ -97,12 +95,12 @@ export class MentionListComponent implements OnInit {
 
   activateNextItem() {
     // adjust scrollable-menu offset if the next item is out of view
-    let listEl: HTMLElement = this.list.nativeElement;
-    let activeEl = listEl.getElementsByClassName('active').item(0);
+    const listEl: HTMLElement = this.list.nativeElement;
+    const activeEl = listEl.getElementsByClassName('active').item(0);
     if (activeEl) {
-      let nextLiEl: HTMLElement = <HTMLElement> activeEl.nextSibling;
-      if (nextLiEl && nextLiEl.nodeName == "LI") {
-        let nextLiRect: ClientRect = nextLiEl.getBoundingClientRect();
+      const nextLiEl: HTMLElement = <HTMLElement> activeEl.nextSibling;
+      if (nextLiEl && nextLiEl.nodeName === 'LI') {
+        const nextLiRect: ClientRect = nextLiEl.getBoundingClientRect();
         if (nextLiRect.bottom > listEl.getBoundingClientRect().bottom) {
           listEl.scrollTop = nextLiEl.offsetTop + nextLiRect.height - listEl.clientHeight;
         }
@@ -114,12 +112,12 @@ export class MentionListComponent implements OnInit {
 
   activatePreviousItem() {
     // adjust the scrollable-menu offset if the previous item is out of view
-    let listEl: HTMLElement = this.list.nativeElement;
-    let activeEl = listEl.getElementsByClassName('active').item(0);
+    const listEl: HTMLElement = this.list.nativeElement;
+    const activeEl = listEl.getElementsByClassName('active').item(0);
     if (activeEl) {
-      let prevLiEl: HTMLElement = <HTMLElement> activeEl.previousSibling;
-      if (prevLiEl && prevLiEl.nodeName == "LI") {
-        let prevLiRect: ClientRect = prevLiEl.getBoundingClientRect();
+      const prevLiEl: HTMLElement = <HTMLElement> activeEl.previousSibling;
+      if (prevLiEl && prevLiEl.nodeName === 'LI') {
+        const prevLiRect: ClientRect = prevLiEl.getBoundingClientRect();
         if (prevLiRect.top < listEl.getBoundingClientRect().top) {
           listEl.scrollTop = prevLiEl.offsetTop;
         }

--- a/src/mention/mention-list.component.ts
+++ b/src/mention/mention-list.component.ts
@@ -6,6 +6,11 @@ import {
 import { isInputOrTextAreaElement, getContentEditableCaretCoords } from './mention-utils';
 import { getCaretCoordinates } from './caret-coords';
 
+export interface IMentionListConfig {
+  headerTemplate?: TemplateRef<any>;
+  itemTemplate?: TemplateRef<any>;
+}
+
 /**
  * Angular 2 Mentions.
  * https://github.com/dmacfarlane/angular-mentions
@@ -34,8 +39,10 @@ import { getCaretCoordinates } from './caret-coords';
     <ng-template #defaultItemTemplate let-item="item">
       {{item[labelKey]}}
     </ng-template>
+    
     <ul #list [hidden]="hidden" class="dropdown-menu scrollable-menu">
-        <li *ngFor="let item of items; let i = index" [class.active]="activeIndex==i">
+      <ng-container *ngIf="mentionListConfig" [ngTemplateOutlet]="mentionListConfig.headerTemplate"></ng-container>
+      <li *ngFor="let item of items; let i = index" [class.active]="activeIndex==i">
             <a class="dropdown-item" (mousedown)="activeIndex=i;itemClick.emit();$event.preventDefault()">
               <ng-template [ngTemplateOutlet]="itemTemplate" [ngTemplateOutletContext]="{'item':item}"></ng-template>
             </a>
@@ -44,18 +51,23 @@ import { getCaretCoordinates } from './caret-coords';
     `
 })
 export class MentionListComponent implements OnInit {
+  @Input() mentionListConfig: IMentionListConfig = {};
   @Input() labelKey = 'label';
-  @Input() itemTemplate: TemplateRef<any>;
+
   @Output() itemClick = new EventEmitter();
+
   @ViewChild('list') list: ElementRef;
   @ViewChild('defaultItemTemplate') defaultItemTemplate: TemplateRef<any>;
+
+  itemTemplate: TemplateRef<any>;
   items = [];
   activeIndex = 0;
   hidden = false;
+
   constructor(private _element: ElementRef) {}
 
   ngOnInit() {
-    if (!this.itemTemplate) {
+    if (!this.mentionListConfig || !this.mentionListConfig.itemTemplate) {
       this.itemTemplate = this.defaultItemTemplate;
     }
   }
@@ -64,7 +76,7 @@ export class MentionListComponent implements OnInit {
   position(nativeParentElement: HTMLInputElement, iframe: HTMLIFrameElement = null) {
     let coords = { top: 0, left: 0 };
     if (isInputOrTextAreaElement(nativeParentElement)) {
-      // parent elements need to have postition:relative for this to work correctly?
+      // parent elements need to have position:relative for this to work correctly?
       coords = getCaretCoordinates(nativeParentElement, nativeParentElement.selectionStart);
       coords.top = nativeParentElement.offsetTop + coords.top + 16;
       coords.left = nativeParentElement.offsetLeft + coords.left;

--- a/src/mention/mention-list.component.ts
+++ b/src/mention/mention-list.component.ts
@@ -42,8 +42,7 @@ export interface IMentionListConfig {
     </ng-template>
 
     <ul #list [hidden]="hidden"
-        [class]="mentionListConfig.listClasses
-         ? 'dropdown-menu scrollable-menu ' + mentionListConfig.listClasses : 'dropdown-menu scrollable-menu'">
+        [class]="mentionListConfig.listClasses ? mentionListConfig.listClasses : 'dropdown-menu scrollable-menu'">
       <ng-container *ngIf="mentionListConfig" [ngTemplateOutlet]="mentionListConfig.headerTemplate"></ng-container>
       <li *ngFor="let item of items; let i = index" [class.active]="activeIndex==i">
         <a class="dropdown-item" (mousedown)="activeIndex=i;itemClick.emit();$event.preventDefault()">

--- a/src/mention/mention-utils.ts
+++ b/src/mention/mention-utils.ts
@@ -2,11 +2,10 @@
 //
 
 function setValue(el: HTMLInputElement, value: any) {
-  //console.log("setValue", el.nodeName, "["+value+"]");
+  // console.log("setValue", el.nodeName, "["+value+"]");
   if (isInputOrTextAreaElement(el)) {
     el.value = value;
-  }
-  else {
+  } else {
     el.textContent = value;
   }
 }
@@ -23,18 +22,18 @@ export function insertValue(
   iframe: HTMLIFrameElement,
   noRecursion: boolean = false
 ) {
-  //console.log("insertValue", el.nodeName, start, end, "["+text+"]", el);
+
+  // console.log("insertValue", el.nodeName, start, end, "["+text+"]", el);
   if (isTextElement(el)) {
-    let val = getValue(el);
+    const val = getValue(el);
     setValue(el, val.substring(0, start) + text + val.substring(end, val.length));
     setCaretPosition(el, start + text.length, iframe);
-  }
-  else if (!noRecursion) {
-    let selObj: Selection = getWindowSelection(iframe);
+  } else if (!noRecursion) {
+    const selObj: Selection = getWindowSelection(iframe);
     if (selObj && selObj.rangeCount > 0) {
-      var selRange = selObj.getRangeAt(0);
-      var position = selRange.startOffset;
-      var anchorNode = selObj.anchorNode;
+      const selRange = selObj.getRangeAt(0);
+      const position = selRange.startOffset;
+      const anchorNode = selObj.anchorNode;
       // if (text.endsWith(' ')) {
       //   text = text.substring(0, text.length-1) + '\xA0';
       // }
@@ -44,40 +43,38 @@ export function insertValue(
 }
 
 export function isInputOrTextAreaElement(el: HTMLElement): boolean {
-  return el != null && (el.nodeName == 'INPUT' || el.nodeName == 'TEXTAREA');
+  return el != null && (el.nodeName === 'INPUT' || el.nodeName === 'TEXTAREA');
 };
 
 export function isTextElement(el: HTMLElement): boolean {
-  return el != null && (el.nodeName == 'INPUT' || el.nodeName == 'TEXTAREA' || el.nodeName == '#text');
+  return el != null && (el.nodeName === 'INPUT' || el.nodeName === 'TEXTAREA' || el.nodeName === '#text');
 };
 
 export function setCaretPosition(el: HTMLInputElement, pos: number, iframe: HTMLIFrameElement = null) {
-  //console.log("setCaretPosition", pos, el, iframe==null);
+  // console.log("setCaretPosition", pos, el, iframe==null);
   if (isInputOrTextAreaElement(el) && el.selectionStart) {
     el.focus();
     el.setSelectionRange(pos, pos);
-  }
-  else {
-    let range = getDocument(iframe).createRange();
+  } else {
+    const range = getDocument(iframe).createRange();
     range.setStart(el, pos);
     range.collapse(true);
-    let sel = getWindowSelection(iframe);
+    const sel = getWindowSelection(iframe);
     sel.removeAllRanges();
     sel.addRange(range);
   }
 }
 
 export function getCaretPosition(el: HTMLInputElement, iframe: HTMLIFrameElement = null) {
-  //console.log("getCaretPosition", el);
+  // console.log("getCaretPosition", el);
   if (isInputOrTextAreaElement(el)) {
-    var val = el.value;
+    const val = el.value;
     return val.slice(0, el.selectionStart).length;
-  }
-  else {
-    var selObj = getWindowSelection(iframe); //window.getSelection();
-    if (selObj.rangeCount>0) {
-      var selRange = selObj.getRangeAt(0);
-      var position = selRange.startOffset;
+  } else {
+    const selObj = getWindowSelection(iframe); // window.getSelection();
+    if (selObj.rangeCount > 0) {
+      const selRange = selObj.getRangeAt(0);
+      const position = selRange.startOffset;
       return position;
     }
   }
@@ -103,28 +100,28 @@ function getWindowSelection(iframe: HTMLIFrameElement): Selection {
 }
 
 export function getContentEditableCaretCoords(ctx: { iframe: HTMLIFrameElement, parent?: Element }) {
-  let markerTextChar = '\ufeff';
-  let markerId = 'sel_' + new Date().getTime() + '_' + Math.random().toString().substr(2);
-  let doc = getDocument(ctx ? ctx.iframe : null);
-  let sel = getWindowSelection(ctx ? ctx.iframe : null);
-  let prevRange = sel.getRangeAt(0);
+  const markerTextChar = '\ufeff';
+  const markerId = 'sel_' + new Date().getTime() + '_' + Math.random().toString().substr(2);
+  const doc = getDocument(ctx ? ctx.iframe : null);
+  const sel = getWindowSelection(ctx ? ctx.iframe : null);
+  const prevRange = sel.getRangeAt(0);
 
   // create new range and set postion using prevRange
-  let range = doc.createRange();
+  const range = doc.createRange();
   range.setStart(sel.anchorNode, prevRange.startOffset);
   range.setEnd(sel.anchorNode, prevRange.startOffset);
   range.collapse(false);
 
   // Create the marker element containing a single invisible character
   // using DOM methods and insert it at the position in the range
-  let markerEl = doc.createElement('span');
+  const markerEl = doc.createElement('span');
   markerEl.id = markerId;
   markerEl.appendChild(doc.createTextNode(markerTextChar));
   range.insertNode(markerEl);
   sel.removeAllRanges();
   sel.addRange(prevRange);
 
-  let coordinates = {
+  const coordinates = {
     left: 0,
     top: markerEl.offsetHeight
   };
@@ -136,14 +133,14 @@ export function getContentEditableCaretCoords(ctx: { iframe: HTMLIFrameElement, 
 }
 
 function localToRelativeCoordinates(
-  ctx: { iframe: HTMLIFrameElement, parent?: Element }, 
-  element: Element, 
+  ctx: { iframe: HTMLIFrameElement, parent?: Element },
+  element: Element,
   coordinates: { top: number; left: number }
 ) {
   let obj = <HTMLElement>element;
   let iframe = ctx ? ctx.iframe : null;
   while (obj) {
-    if (ctx.parent != null && ctx.parent == obj) {
+    if (ctx.parent != null && ctx.parent === obj) {
       break;
     }
     coordinates.left += obj.offsetLeft + obj.clientLeft;
@@ -157,7 +154,7 @@ function localToRelativeCoordinates(
   obj = <HTMLElement>element;
   iframe = ctx ? ctx.iframe : null;
   while (obj !== getDocument(null).body && obj != null) {
-    if (ctx.parent != null && ctx.parent == obj) {
+    if (ctx.parent != null && ctx.parent === obj) {
       break;
     }
     if (obj.scrollTop && obj.scrollTop > 0) {

--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -26,11 +26,11 @@ export interface ItemsDescription {
 
 export interface IMentionConfig {
   triggerChar: string;
-  labelKey: string,
+  labelKey: string;
   keyCodeSpecified: boolean;
   disableSearch: boolean;
   maxItems: number;
-  mentionSelect: IMentionLabelSelector,
+  mentionSelect: IMentionLabelSelector;
 }
 
 export type IMentionLabelSelector = (item: any, labelKey?: string, triggerChar?: string) => string;

--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -1,8 +1,8 @@
-import { Directive, ElementRef, Input, ComponentFactoryResolver, ViewContainerRef, TemplateRef } from "@angular/core";
-import { EventEmitter, Output, OnInit, OnChanges, SimpleChanges } from "@angular/core";
+import {Directive, ElementRef, Input, ComponentFactoryResolver, ViewContainerRef, TemplateRef} from '@angular/core';
+import {EventEmitter, Output, OnInit, OnChanges, SimpleChanges} from '@angular/core';
 
-import { MentionListComponent } from './mention-list.component';
-import { getValue, insertValue, getCaretPosition, setCaretPosition } from './mention-utils';
+import {MentionListComponent} from './mention-list.component';
+import {getValue, insertValue, getCaretPosition, setCaretPosition} from './mention-utils';
 
 const KEY_BACKSPACE = 8;
 const KEY_TAB = 9;
@@ -31,13 +31,13 @@ const KEY_2 = 50;
 })
 export class MentionDirective implements OnInit, OnChanges {
 
-  @Input() set mention(items:any[]){
+  @Input() set mention(items: any[]) {
     this.items = items;
   }
 
-  @Input() set mentionConfig(config:any) {
+  @Input() set mentionConfig(config: any) {
     this.triggerChar = config.triggerChar || this.triggerChar;
-    this.keyCodeSpecified = typeof this.triggerChar === 'number'
+    this.keyCodeSpecified = typeof this.triggerChar === 'number';
     this.labelKey = config.labelKey || this.labelKey;
     this.disableSearch = config.disableSearch || this.disableSearch;
     this.maxItems = config.maxItems || this.maxItems;
@@ -50,22 +50,6 @@ export class MentionDirective implements OnInit, OnChanges {
   // event emitted whenever the search term changes
   @Output() searchTerm = new EventEmitter();
 
-  // the character that will trigger the menu behavior
-  private triggerChar: string | number = "@";
-
-  // option to specify the field in the objects to be used as the item label
-  private labelKey:string = 'label';
-
-  // option to diable internal filtering. can be used to show the full list returned
-  // from an async operation (or allows a custom filter function to be used - in future)
-  private disableSearch:boolean = false;
-
-  // option to limit the number of items shown in the pop-up menu
-  private maxItems:number = -1;
-
-  // optional function to format the selected item before inserting the text
-  private mentionSelect: (item: any) => (string) = (item: any) => this.triggerChar + item[this.labelKey];
-
   searchString: string;
   startPos: number;
   items: any[];
@@ -75,26 +59,43 @@ export class MentionDirective implements OnInit, OnChanges {
   iframe: any; // optional
   keyCodeSpecified: boolean;
 
+  // the character that will trigger the menu behavior
+  private triggerChar: string | number = '@';
+
+  // option to specify the field in the objects to be used as the item label
+  private labelKey = 'label';
+
+  // option to diable internal filtering. can be used to show the full list returned
+  // from an async operation (or allows a custom filter function to be used - in future)
+  private disableSearch = false;
+
+  // option to limit the number of items shown in the pop-up menu
+  private maxItems: number = -1;
+
+  // optional function to format the selected item before inserting the text
+  private mentionSelect: (item: any) => (string) = (item: any) => this.triggerChar + item[this.labelKey];
+
   constructor(
     private _element: ElementRef,
     private _componentResolver: ComponentFactoryResolver,
     private _viewContainerRef: ViewContainerRef
-  ) {}
+  ) {
+  }
 
   ngOnInit() {
-    if (this.items && this.items.length>0) {
-      if (typeof this.items[0] == 'string') {
+    if (this.items && this.items.length > 0) {
+      if (typeof this.items[0] === 'string') {
         // convert strings to objects
         const me = this;
-        this.items = this.items.map(function(label){
-          let object = {};
+        this.items = this.items.map(function (label) {
+          const object = {};
           object[me.labelKey] = label;
           return object;
         });
       }
       // remove items without an labelKey (as it's required to filter the list)
       this.items = this.items.filter(e => e[this.labelKey]);
-      this.items.sort((a,b)=>a[this.labelKey].localeCompare(b[this.labelKey]));
+      this.items.sort((a, b) => a[this.labelKey].localeCompare(b[this.labelKey]));
       if (this.searchList && !this.searchList.hidden) {
         this.updateSearchList();
       }
@@ -112,7 +113,7 @@ export class MentionDirective implements OnInit, OnChanges {
   }
 
   stopEvent(event: any) {
-    //if (event instanceof KeyboardEvent) { // does not work for iframe
+    // if (event instanceof KeyboardEvent) { // does not work for iframe
     if (!event.wasClick) {
       event.preventDefault();
       event.stopPropagation();
@@ -129,59 +130,54 @@ export class MentionDirective implements OnInit, OnChanges {
   }
 
   keyHandler(event: any, nativeElement: HTMLInputElement = this._element.nativeElement) {
-    let val: string = getValue(nativeElement);
+    const val: string = getValue(nativeElement);
     let pos = getCaretPosition(nativeElement, this.iframe);
     let charPressed = this.keyCodeSpecified ? event.keyCode : event.key;
     if (!charPressed) {
-      let charCode = event.which || event.keyCode;
+      const charCode = event.which || event.keyCode;
       if (!event.shiftKey && (charCode >= 65 && charCode <= 90)) {
         charPressed = String.fromCharCode(charCode + 32);
-      }
-      else if (event.shiftKey && charCode === KEY_2) {
+      } else if (event.shiftKey && charCode === KEY_2) {
         charPressed = this.triggerChar;
-      }
-      else {
+      } else {
         // TODO (dmacfarlane) fix this for non-alpha keys
         // http://stackoverflow.com/questions/2220196/how-to-decode-character-pressed-from-jquerys-keydowns-event-handler?lq=1
         charPressed = String.fromCharCode(event.which || event.keyCode);
       }
     }
-    if (event.keyCode == KEY_ENTER && event.wasClick && pos < this.startPos) {
+    if (event.keyCode === KEY_ENTER && event.wasClick && pos < this.startPos) {
       // put caret back in position prior to contenteditable menu click
       pos = this.startNode.length;
       setCaretPosition(this.startNode, pos, this.iframe);
     }
-    //console.log("keyHandler", this.startPos, pos, val, charPressed, event);
-    if (charPressed == this.triggerChar) {
+
+    // console.log("keyHandler", this.startPos, pos, val, charPressed, event);
+
+    if (charPressed === this.triggerChar) {
       this.startPos = pos;
       this.startNode = (this.iframe ? this.iframe.contentWindow.getSelection() : window.getSelection()).anchorNode;
       this.stopSearch = false;
       this.searchString = null;
       this.showSearchList(nativeElement);
       this.updateSearchList();
-    }
-    else if (this.startPos >= 0 && !this.stopSearch) {
+    } else if (this.startPos >= 0 && !this.stopSearch) {
       if (pos <= this.startPos) {
         this.searchList.hidden = true;
-      }
-      // ignore shift when pressed alone, but not when used with another key
-      else if (event.keyCode !== KEY_SHIFT &&
-          !event.metaKey &&
-          !event.altKey &&
-          !event.ctrlKey &&
-          pos > this.startPos
+      } else if (event.keyCode !== KEY_SHIFT && // ignore shift when pressed alone, but not when used with another key
+        !event.metaKey &&
+        !event.altKey &&
+        !event.ctrlKey &&
+        pos > this.startPos
       ) {
         if (event.keyCode === KEY_SPACE) {
           this.startPos = -1;
-        }
-        else if (event.keyCode === KEY_BACKSPACE && pos > 0) {
+        } else if (event.keyCode === KEY_BACKSPACE && pos > 0) {
           pos--;
-          if (pos==0) {
+          if (pos === 0) {
             this.stopSearch = true;
           }
           this.searchList.hidden = this.stopSearch;
-        }
-        else if (!this.searchList.hidden) {
+        } else if (!this.searchList.hidden) {
           if (event.keyCode === KEY_TAB || event.keyCode === KEY_ENTER) {
             this.stopEvent(event);
             this.searchList.hidden = true;
@@ -190,26 +186,23 @@ export class MentionDirective implements OnInit, OnChanges {
             insertValue(nativeElement, this.startPos, pos,
               this.mentionSelect(this.searchList.activeItem), this.iframe);
             // fire input event so angular bindings are updated
-            if ("createEvent" in document) {
-              var evt = document.createEvent("HTMLEvents");
-              evt.initEvent("input", false, true);
+            if ('createEvent' in document) {
+              const evt = document.createEvent('HTMLEvents');
+              evt.initEvent('input', false, true);
               nativeElement.dispatchEvent(evt);
             }
             this.startPos = -1;
             return false;
-          }
-          else if (event.keyCode === KEY_ESCAPE) {
+          } else if (event.keyCode === KEY_ESCAPE) {
             this.stopEvent(event);
             this.searchList.hidden = true;
             this.stopSearch = true;
             return false;
-          }
-          else if (event.keyCode === KEY_DOWN) {
+          } else if (event.keyCode === KEY_DOWN) {
             this.stopEvent(event);
             this.searchList.activateNextItem();
             return false;
-          }
-          else if (event.keyCode === KEY_UP) {
+          } else if (event.keyCode === KEY_UP) {
             this.stopEvent(event);
             this.searchList.activatePreviousItem();
             return false;
@@ -219,8 +212,7 @@ export class MentionDirective implements OnInit, OnChanges {
         if (event.keyCode === KEY_LEFT || event.keyCode === KEY_RIGHT) {
           this.stopEvent(event);
           return false;
-        }
-        else {
+        } else {
           let mention = val.substring(this.startPos + 1, pos);
           if (event.keyCode !== KEY_BACKSPACE) {
             mention += charPressed;
@@ -239,7 +231,7 @@ export class MentionDirective implements OnInit, OnChanges {
       let objects = this.items;
       // disabling the search relies on the async operation to do the filtering
       if (!this.disableSearch && this.searchString) {
-        let searchStringLowerCase = this.searchString.toLowerCase();
+        const searchStringLowerCase = this.searchString.toLowerCase();
         objects = this.items.filter(e => e[this.labelKey].toLowerCase().startsWith(searchStringLowerCase));
       }
       matches = objects;
@@ -250,25 +242,24 @@ export class MentionDirective implements OnInit, OnChanges {
     // update the search list
     if (this.searchList) {
       this.searchList.items = matches;
-      this.searchList.hidden = matches.length == 0;
+      this.searchList.hidden = matches.length === 0;
     }
   }
 
   showSearchList(nativeElement: HTMLInputElement) {
     if (this.searchList == null) {
-      let componentFactory = this._componentResolver.resolveComponentFactory(MentionListComponent);
-      let componentRef = this._viewContainerRef.createComponent(componentFactory);
+      const componentFactory = this._componentResolver.resolveComponentFactory(MentionListComponent);
+      const componentRef = this._viewContainerRef.createComponent(componentFactory);
       this.searchList = componentRef.instance;
       this.searchList.position(nativeElement, this.iframe);
       this.searchList.itemTemplate = this.mentionListTemplate;
       this.searchList.labelKey = this.labelKey;
       componentRef.instance['itemClick'].subscribe(() => {
         nativeElement.focus();
-        let fakeKeydown = {"keyCode":KEY_ENTER,"wasClick":true};
+        const fakeKeydown = {'keyCode': KEY_ENTER, 'wasClick': true};
         this.keyHandler(fakeKeydown, nativeElement);
       });
-    }
-    else {
+    } else {
       this.searchList.activeIndex = 0;
       this.searchList.position(nativeElement, this.iframe);
       window.setTimeout(() => this.searchList.resetScroll());

--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -107,7 +107,7 @@ export class MentionDirective implements OnInit, OnChanges {
   }
 
   private initializeItemsList(items: any[], labelKey: string) {
-    if (typeof items === 'string') {
+    if (typeof items[0] === 'string') {
       // convert strings to objects
       const me = this;
       items = (<string[]>items).map(function (label) {

--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -1,9 +1,8 @@
 import {Directive, ElementRef, Input, ComponentFactoryResolver, ViewContainerRef, TemplateRef} from '@angular/core';
 import {EventEmitter, Output, OnInit, OnChanges, SimpleChanges} from '@angular/core';
 
-import {MentionListComponent} from './mention-list.component';
+import {IMentionListConfig, MentionListComponent} from './mention-list.component';
 import {getValue, insertValue, getCaretPosition, setCaretPosition} from './mention-utils';
-import {isArray} from 'util';
 
 const KEY_BACKSPACE = 8;
 const KEY_TAB = 9;
@@ -25,8 +24,16 @@ export interface ItemsDescription {
   mentionSelect?: IMentionLabelSelector;
 }
 
-export type IMentionLabelSelector = (item: any, labelKey?: string, triggerChar?: string) => string;
+export interface IMentionConfig {
+  triggerChar: string;
+  labelKey: string,
+  keyCodeSpecified: boolean;
+  disableSearch: boolean;
+  maxItems: number;
+  mentionSelect: IMentionLabelSelector,
+}
 
+export type IMentionLabelSelector = (item: any, labelKey?: string, triggerChar?: string) => string;
 
 /**
  * Angular 2 Mentions.
@@ -57,7 +64,7 @@ export class MentionDirective implements OnInit, OnChanges {
     }
   }
 
-  @Input() set mentionConfig(config: any) {
+  @Input() set mentionConfig(config: IMentionConfig) {
     if (!this.multipleItems) {
       this.triggerChar = [config.triggerChar] || this.triggerChar;
     }
@@ -69,7 +76,7 @@ export class MentionDirective implements OnInit, OnChanges {
   }
 
   // template to use for rendering list items
-  @Input() mentionListTemplate: TemplateRef<any>;
+  @Input() mentionListConfig: IMentionListConfig;
 
   // event emitted whenever the search term changes
   @Output() searchTerm = new EventEmitter();
@@ -323,7 +330,7 @@ export class MentionDirective implements OnInit, OnChanges {
       const componentRef = this._viewContainerRef.createComponent(componentFactory);
       this.searchList = componentRef.instance;
       this.searchList.position(nativeElement, this.iframe);
-      this.searchList.itemTemplate = this.mentionListTemplate;
+      this.searchList.mentionListConfig = this.mentionListConfig;
       this.searchList.labelKey = this.labelKey;
       componentRef.instance['itemClick'].subscribe(() => {
         nativeElement.focus();

--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -95,7 +95,8 @@ export class MentionDirective implements OnInit, OnChanges {
   private maxItems: number = -1;
 
   // optional function to format the selected item before inserting the text
-  private mentionSelect: (item: any) => (string) = (item: any) => this.triggerChar + item[this.labelKey];
+  private mentionSelect: (item: any, triggerChar?: string) => string
+    = (item: any, triggerChar?: string) => this.triggerChar + item[this.labelKey];
 
   constructor(
     private _element: ElementRef,


### PR DESCRIPTION
Allow as several sites do to use multiple trigger chars to show different autocomplete options.

Example of this: 

* Slack @ - users; # - channels
* Github @ - users; # - issues